### PR TITLE
added Laser Stimulation; improved timing

### DIFF
--- a/MultiNoseportController/MultiNoseportController.ino
+++ b/MultiNoseportController/MultiNoseportController.ino
@@ -1,16 +1,31 @@
 
 #include "NosePort.h"
 
+// Set this to 1 for debug mode, otherwise set to 0
+#define DEBUG_MODE 0
+
+#if DEBUG_MODE
+  int debugPin = 12;  // Pin 12 will be in use in DEBUG MODE
+#endif
 
 void DEBUG(String message) {
-  //Serial.println(message.c_str()); // comment this out when not debugging !!!!!!!
+#if DEBUG_MODE
+  Serial.println(message.c_str());
+#endif
 }
+
+bool alternateLoopFlag = false; // DEBUG
 
 void setup() {
   // set up USB communication at 115200 baud
   Serial.begin(115200);
   // tell PC that we're running by sending 'S' message
   Serial.println("S");
+
+  // DEBUG
+#if DEBUG_MODE
+  pinMode(debugPin, OUTPUT);
+#endif
 }
 
 void loop() {
@@ -38,4 +53,13 @@ void loop() {
     p->update();
   }
 
+  // DEBUG
+#if DEBUG_MODE
+  if (alternateLoopFlag) {
+    digitalWrite(debugPin, HIGH);
+  } else {
+    digitalWrite(debugPin, LOW);
+  }
+  alternateLoopFlag = !alternateLoopFlag;
+#endif
 }

--- a/MultiNoseportController/NosePort.h
+++ b/MultiNoseportController/NosePort.h
@@ -12,16 +12,23 @@ private:
   int _nosePortNumber;
   int _beambreakPin;
   int _solenoidPin;
-  int _ledPin;
   bool _rewardActivated;
-  long _rewardDuration;
+  unsigned long _rewardDuration_us;
   bool _singleReward;
-  // long _noseInTime;
-  // long _noseOutTime;
-
+  int _ledPin;
+  int _laserPin;
+  bool _laserActivated;
+  unsigned long _laserStimDelay_us;
+  unsigned long _laserStimDur_us;
+  unsigned long _laserPulseDur_us;
+  unsigned long _laserPulsePeriod_us;
+  bool _duringLaserStim;
+  unsigned long _laserStimStartTime_us;
+  bool _laserOn;
+ 
   bool _noseIn;
   bool _duringReward;
-  long _rewardEndTime;
+  unsigned long _rewardStartTime_us;
 
 public:
 
@@ -36,17 +43,25 @@ public:
   NosePort(int beambreakPin, int solenoidPin);
   //~NosePort();
 
-  // public methods
-  void setRewardDuration(long duration);
+  // public methods                           All API times are in milliseconds:
+  void setRewardDuration(long duration);      // in ms
   void setActivated(bool activated);
   void setSingleReward(bool singleReward);
+  void deliverReward();
   void noseIn();
   void noseOut();
   void setLEDPin(int pin);
   void ledOn();
   void ledOff();
+  void setLaserPin(int pin);
+  void setLaserDelay(long delay);             // in ms
+  void setLaserStimDuration(long stimDur);    // in ms
+  void setLaserPulseDuration(long pulseDur);  // in ms
+  void setLaserPulsePeriod(long pulseRate);   // in ms
+  void setLaserActive(bool activated);
+  void startLaserStim();
+  void endLaserStim();
   void update();
-  void deliverReward();
   void logToUSB(char message);
 
   void identify(); // for debugging

--- a/triplePortCode_v5/NosePort.m
+++ b/triplePortCode_v5/NosePort.m
@@ -8,12 +8,17 @@ classdef NosePort  < handle
         solenoidPin = 0;
         ledPin = 0;
         ledState = 0;
+        laserPin = 0;
+        laserActive = 0;
         noseInFunc = [];
         noseOutFunc = [];
         rewardFunc = [];
+        laserOnFunc = [];
+        laserOffFunc = [];
     end
 
     methods
+        %% constructor
         function obj = NosePort(beambreakPin, solenoidPin)
             global newPortID
             newPortID = 0;
@@ -30,6 +35,7 @@ classdef NosePort  < handle
             AllNosePorts{newPortID} = obj;
         end
 
+        %% Reward & nose detection methods
         function setToSingleRewardMode(obj)
             obj.arduinoCommand('S',1);
         end
@@ -63,6 +69,8 @@ classdef NosePort  < handle
                 feval(obj.rewardFunc,obj.portID);
             end
         end
+
+        %% LED methods
         function setLEDPin(obj, pin)
             obj.ledPin = pin;
             obj.arduinoCommand('L', pin);
@@ -82,7 +90,41 @@ classdef NosePort  < handle
             end
         end
 
+        %% Laser methods
+        function setLaserPin(obj, pin)
+            obj.laserPin = pin;
+            obj.arduinoCommand('P', pin);
+        end
+        function setLaserDelay(obj, delay)
+            obj.arduinoCommand('Y', delay);
+        end
+        function setLaserStimDuration(obj, duration)
+            obj.arduinoCommand('T', duration);
+        end
+        function setLaserPulseDuration(obj, pulseDur)
+            obj.arduinoCommand('U', pulseDur);
+        end
+        function setLaserPulsePeriod(obj, pulsePeriod)
+            obj.arduinoCommand('I', pulsePeriod);
+        end
+        function activateLaser(obj)
+            obj.arduinoCommand('V', 1);
+        end
+        function deactivateLaser(obj)
+            obj.arduinoCommand('V', 0);
+        end
+        function laserOn(obj)
+            if isa(obj.laserOnFunc,'function_handle')
+                feval(obj.laserOnFunc, obj.portID);
+            end
+        end
+        function laserOff(obj)
+            if isa(obj.laserOffFunc,'function_handle')
+                feval(obj.laserOffFunc, obj.portID);
+            end
+        end
 
+        %% arduinoCommand method
         function arduinoCommand(obj, messageChar, value)
             writeToArduino(messageChar, obj.portID, value)
         end

--- a/triplePortCode_v5/interpretArduinoMessage.m
+++ b/triplePortCode_v5/interpretArduinoMessage.m
@@ -38,6 +38,17 @@ switch messageType
         logValue('Reward delivered', portNum);
         AllNosePorts{portNum}.reward();
         %rewardArray = [rewardArray, 1];
+
+    case 'L'
+        % Laser stim started
+        logValue('Laser on', portNum);
+        AllNosePorts{portNum}.laserOn();
+    case 'l'
+        % Laser stim ended
+        logValue('Laser off', portNum);
+        AllNosePorts{portNum}.laserOff();
+
+
     case '#'
         % Error
         logEvent('Arduino ERROR');


### PR DESCRIPTION
Major addition:

Added a laser pin to NosePort:
- laser can be in activated or deactivated state
- when activated, the laser is triggered by a nose-in event
- upon triggereing, there is a delay, followed by a laser pulse train strimulus
- delay, stimDuration, pulseDuration, and pulsePeriod are all user-configurable through Matlab
- Matlab callbacks for laserOn and laserOff (laserOn is when the delay period is over)

——

Minor fix:
- on the Ardunio, all timing is measured in microseconds, to improve accuracy.
- Matlab code still specifies times in milliseconds.